### PR TITLE
Modified utils.py's "plt.style.use" to handle different "seaborn-ticks" versions

### DIFF
--- a/pyhhmm/utils.py
+++ b/pyhhmm/utils.py
@@ -14,7 +14,18 @@ from prettytable import PrettyTable
 import seaborn as sns
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
-plt.style.use('seaborn-ticks')
+import warnings
+
+# Check if a style containing "seaborn-ticks" is available
+# if so, returns the first match
+ticks_style = next(
+    (style for style in plt.style.available \
+        if "seaborn" in style and "ticks" in style), None)
+
+if ticks_style:
+    plt.style.use(ticks_style)
+else:
+    warnings.warn("Seaborn-ticks style not found. Using the default style.")
 
 COVARIANCE_TYPES = frozenset(('spherical', 'tied', 'diagonal', 'full'))
 COLORS = sns.color_palette('colorblind', n_colors=15)


### PR DESCRIPTION
First and foremost I would like to thank the authors for their amazing contribution.

I was facing a problem when replicating the code contained in the documentation because of utils.py's line 17:
`plt.style.use('seaborn-ticks')`

which was raising the following error:
`OSError: 'seaborn-ticks' is not a valid package style, path of style file, URL of style file, or library style name (library styles are listed in style.available)`

This happened in different Conda/Micromamba environments and also in Google Colab. To address this issue, I modified some lines in utils.py to handle this case and check if there is a style available containing "seaborn-ticks" (in both my local Python and Colab cases we had a version called "seaborn-v0_8-ticks", hence the error). 

This new code should circumvent this by checking and selecting the first instance where both "seaborn" and "ticks" are present; if there is no match, then we just use the default style and issue a warning with `warnings` that is also displayed in a convenient way in a Jupyter Notebook.